### PR TITLE
Add Amie's bottom sheet requirements

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -117,9 +117,20 @@ open class PanModalPresentationController: UIPresentationController {
         } else {
             view = DimmedView()
         }
-        view.didTap = { [weak self] _ in
-            if self?.presentable?.allowsTapToDismiss == true {
-                self?.presentedViewController.dismiss(animated: true)
+        if let backgroundInteraction = self.presentable?.backgroundInteraction {
+            switch backgroundInteraction {
+            case .forward:
+                view.hitTestHandler = { [weak self] (point, event) in
+                    return self?.presentingViewController.view.hitTest(point, with: event)
+                }
+
+            case .dismiss:
+                view.didTap = { [weak self] _ in
+                    self?.presentedViewController.dismiss(animated: true)
+                }
+
+            default:
+                break
             }
         }
         return view

--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -30,6 +30,7 @@ open class PanModalPresentationController: UIPresentationController {
      */
     public enum PresentationState {
         case shortForm
+        case mediumForm
         case longForm
     }
 
@@ -78,6 +79,11 @@ open class PanModalPresentationController: UIPresentationController {
      The y value for the short form presentation state
      */
     private var shortFormYPosition: CGFloat = 0
+    
+    /**
+     The y value for the medium form presentation state
+     */
+    private var mediumFormYPosition: CGFloat = 0
 
     /**
      The y value for the long form presentation state
@@ -262,6 +268,8 @@ public extension PanModalPresentationController {
         switch state {
         case .shortForm:
             snap(toYPosition: shortFormYPosition)
+        case .mediumForm:
+            snap(toYPosition: mediumFormYPosition)
         case .longForm:
             snap(toYPosition: longFormYPosition)
         }
@@ -426,6 +434,7 @@ private extension PanModalPresentationController {
             else { return }
 
         shortFormYPosition = layoutPresentable.shortFormYPos
+        mediumFormYPosition = layoutPresentable.mediumFormYPos
         longFormYPosition = layoutPresentable.longFormYPos
         anchorModalToLongForm = layoutPresentable.anchorModalToLongForm
         extendsPanScrolling = layoutPresentable.allowsExtendedPanScrolling
@@ -515,11 +524,20 @@ private extension PanModalPresentationController {
                  This allows the user to dismiss directly from long form
                  instead of going to the short form state first.
                  */
-                if velocity.y < 0 {
+                if velocity.y < 0 && presentedView.frame.minY < mediumFormYPosition {
                     transition(to: .longForm)
+                    
+                } else if velocity.y < 0 && presentedView.frame.minY < shortFormYPosition {
+                    transition(to: .mediumForm)
 
-                } else if (nearest(to: presentedView.frame.minY, inValues: [longFormYPosition, containerView.bounds.height]) == longFormYPosition
-                    && presentedView.frame.minY < shortFormYPosition) || presentable?.allowsDragToDismiss == false {
+                } else if (nearest(to: presentedView.frame.minY, inValues: [longFormYPosition, containerView.bounds.height]) == longFormYPosition && presentedView.frame.minY < mediumFormYPosition) {
+                    
+                    transition(to: .mediumForm)
+                }
+                
+                else if (nearest(to: presentedView.frame.minY, inValues: [mediumFormYPosition, containerView.bounds.height]) == mediumFormYPosition && presentedView.frame.minY < shortFormYPosition)
+                    || presentable?.allowsDragToDismiss == false
+                {
                     transition(to: .shortForm)
 
                 } else {
@@ -532,11 +550,12 @@ private extension PanModalPresentationController {
                  The `containerView.bounds.height` is used to determine
                  how close the presented view is to the bottom of the screen
                  */
-                let position = nearest(to: presentedView.frame.minY, inValues: [containerView.bounds.height, shortFormYPosition, longFormYPosition])
+                let position = nearest(to: presentedView.frame.minY, inValues: [containerView.bounds.height, shortFormYPosition, mediumFormYPosition, longFormYPosition])
 
                 if position == longFormYPosition {
                     transition(to: .longForm)
-
+                } else if position == mediumFormYPosition {
+                    transition(to: .mediumForm)
                 } else if position == shortFormYPosition || presentable?.allowsDragToDismiss == false {
                     transition(to: .shortForm)
 

--- a/PanModal/Presentable/PanModalBackgroundInteraction.swift
+++ b/PanModal/Presentable/PanModalBackgroundInteraction.swift
@@ -1,0 +1,22 @@
+//
+//  PanModelBackgroundInteraction.swift
+//  PanModal
+//
+//  Created by Ilya Kharlamov on 19.08.2020.
+//  Copyright © 2020 Detail. All rights reserved.
+//
+import Foundation
+
+/** Describes the user interaction events that are triggered as the user taps the background */
+public enum PanModalBackgroundInteraction: Equatable {
+
+    /** Taps dismiss the modal immediately */
+    case dismiss
+
+    /** Touches are forwarded to the lower window (In most cases it would be the application main window that will handle it */
+    case forward
+
+     /** Absorbs touches. The modal does nothing (Swallows the touch) */
+    case none
+
+}

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -85,6 +85,10 @@ public extension PanModalPresentable where Self: UIViewController {
         return true
     }
 
+    var backgroundInteraction: PanModalBackgroundInteraction {
+        return self.allowsTapToDismiss ? .dismiss : .none
+    }
+    
     var isUserInteractionEnabled: Bool {
         return true
     }

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -20,6 +20,10 @@ public extension PanModalPresentable where Self: UIViewController {
     var shortFormHeight: PanModalHeight {
         return longFormHeight
     }
+    
+    var mediumFormHeight:  PanModalHeight {
+        return longFormHeight
+    }
 
     var longFormHeight: PanModalHeight {
 
@@ -84,7 +88,7 @@ public extension PanModalPresentable where Self: UIViewController {
     var isUserInteractionEnabled: Bool {
         return true
     }
-
+    
     var isHapticFeedbackEnabled: Bool {
         return true
     }

--- a/PanModal/Presentable/PanModalPresentable+LayoutHelpers.swift
+++ b/PanModal/Presentable/PanModalPresentable+LayoutHelpers.swift
@@ -62,6 +62,23 @@ extension PanModalPresentable where Self: UIViewController {
         // shortForm shouldn't exceed longForm
         return max(shortFormYPos, longFormYPos)
     }
+    
+    /**
+     Returns the medium form Y position
+
+     - Note: If voiceover is on, the `longFormYPos` is returned.
+     We do not support medium form when voiceover is on as it would make it difficult for user to navigate.
+     */
+    var mediumFormYPos: CGFloat {
+        
+        guard !UIAccessibility.isVoiceOverRunning
+            else { return longFormYPos }
+
+        let mediumFormYPos = topMargin(from: mediumFormHeight) + topOffset
+
+        // shortForm shouldn't exceed longForm
+        return max(mediumFormYPos, longFormYPos)
+    }
 
     /**
      Returns the long form Y position

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -154,6 +154,13 @@ public protocol PanModalPresentable: AnyObject {
     var allowsTapToDismiss: Bool { get }
 
     /**
+     Describes what happens when the user interacts the background view.
+    
+     Default value is .dismiss.
+     */
+    var backgroundInteraction: PanModalBackgroundInteraction { get }
+    
+    /**
      A flag to toggle user interactions on the container view.
 
      - Note: Return false to forward touches to the presentingViewController.

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -45,6 +45,17 @@ public protocol PanModalPresentable: AnyObject {
      */
     var shortFormHeight: PanModalHeight { get }
 
+    
+    /**
+     The height of the pan modal container view
+     when in the mediumForm presentation state.
+
+     This value is capped to .max, if provided value exceeds the space available.
+
+     Default value is the longFormHeight.
+     */
+    var mediumFormHeight: PanModalHeight { get }
+
     /**
      The height of the pan modal container view
      when in the longForm presentation state.
@@ -150,7 +161,7 @@ public protocol PanModalPresentable: AnyObject {
      Default is true.
     */
     var isUserInteractionEnabled: Bool { get }
-
+    
     /**
      A flag to determine if haptic feedback should be enabled during presentation.
 

--- a/PanModal/View/DimmedView.swift
+++ b/PanModal/View/DimmedView.swift
@@ -40,11 +40,24 @@ public class DimmedView: UIView {
             }
         }
     }
+    
+    /**
+     The closure to be executed on hitTest
+     */
+    var hitTestHandler: ((_ point: CGPoint, _ event: UIEvent?) -> UIView?)?
 
     /**
      The closure to be executed when a tap occurs
      */
-    var didTap: ((_ recognizer: UIGestureRecognizer) -> Void)?
+    var didTap: ((_ recognizer: UIGestureRecognizer) -> Void)? {
+        didSet {
+            if self.didTap != nil {
+                addGestureRecognizer(tapGesture)
+            } else {
+                removeGestureRecognizer(tapGesture)
+            }
+        }
+    }
 
     /**
      Tap gesture recognizer
@@ -67,6 +80,10 @@ public class DimmedView: UIView {
     }
 
     // MARK: - Event Handlers
+    
+    public override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        return self.hitTestHandler?(point, event) ?? super.hitTest(point, with: event)
+    }
 
     @objc private func didTapView() {
         didTap?(tapGesture)

--- a/PanModalDemo.xcodeproj/project.pbxproj
+++ b/PanModalDemo.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		0F2A2C682239C15D003BDB2F /* UIViewController+PanModalPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C072A9220BA82A00124CE1 /* UIViewController+PanModalPresenter.swift */; };
 		0F2A2C692239C162003BDB2F /* DimmedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC13906E216D9458007A3E64 /* DimmedView.swift */; };
 		0F2A2C6A2239C165003BDB2F /* PanContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94795C9C21F03368008045A0 /* PanContainerView.swift */; };
+		48EE033725FA8E160069DE6C /* PanModalBackgroundInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48EE033625FA8E160069DE6C /* PanModalBackgroundInteraction.swift */; };
+		48EE034025FA8E320069DE6C /* PanModalBackgroundInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48EE033625FA8E160069DE6C /* PanModalBackgroundInteraction.swift */; };
 		743CABB02225FC9F00634A5A /* UserGroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743CABAF2225FC9F00634A5A /* UserGroupViewController.swift */; };
 		743CABB22225FD1100634A5A /* UserGroupHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743CABB12225FD1100634A5A /* UserGroupHeaderView.swift */; };
 		743CABB42225FE7700634A5A /* UserGroupMemberPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743CABB32225FE7700634A5A /* UserGroupMemberPresentable.swift */; };
@@ -93,6 +95,7 @@
 		0F2A2C512239C119003BDB2F /* PanModal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PanModal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0F2A2C532239C119003BDB2F /* PanModal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PanModal.h; sourceTree = "<group>"; };
 		0F2A2C542239C119003BDB2F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		48EE033625FA8E160069DE6C /* PanModalBackgroundInteraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanModalBackgroundInteraction.swift; sourceTree = "<group>"; };
 		743CABAF2225FC9F00634A5A /* UserGroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserGroupViewController.swift; sourceTree = "<group>"; };
 		743CABB12225FD1100634A5A /* UserGroupHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserGroupHeaderView.swift; sourceTree = "<group>"; };
 		743CABB32225FE7700634A5A /* UserGroupMemberPresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserGroupMemberPresentable.swift; sourceTree = "<group>"; };
@@ -300,6 +303,7 @@
 			isa = PBXGroup;
 			children = (
 				74C072A4220BA76D00124CE1 /* PanModalHeight.swift */,
+				48EE033625FA8E160069DE6C /* PanModalBackgroundInteraction.swift */,
 				DC139068216D9458007A3E64 /* PanModalPresentable.swift */,
 				DCC0EE7B21917F2500208DBC /* PanModalPresentable+Defaults.swift */,
 				DC139069216D9458007A3E64 /* PanModalPresentable+UIViewController.swift */,
@@ -540,6 +544,7 @@
 				0F2A2C642239C14E003BDB2F /* PanModalPresentable+Defaults.swift in Sources */,
 				0F2A2C652239C151003BDB2F /* PanModalPresentable+UIViewController.swift in Sources */,
 				0F2A2C662239C153003BDB2F /* PanModalPresentable+LayoutHelpers.swift in Sources */,
+				48EE033725FA8E160069DE6C /* PanModalBackgroundInteraction.swift in Sources */,
 				0F2A2C672239C157003BDB2F /* PanModalPresenter.swift in Sources */,
 				0F2A2C682239C15D003BDB2F /* UIViewController+PanModalPresenter.swift in Sources */,
 				0F2A2C692239C162003BDB2F /* DimmedView.swift in Sources */,
@@ -587,6 +592,7 @@
 				743CABD322265F2E00634A5A /* ProfileViewController.swift in Sources */,
 				DC139070216D9458007A3E64 /* PanModalPresentationAnimator.swift in Sources */,
 				944EBA2E227BB7F400C4C97B /* FullScreenNavController.swift in Sources */,
+				48EE034025FA8E320069DE6C /* PanModalBackgroundInteraction.swift in Sources */,
 				DCA741AE216D90410021F2F2 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sample/View Controllers/User Groups/UserGroupViewController.swift
+++ b/Sample/View Controllers/User Groups/UserGroupViewController.swift
@@ -101,6 +101,8 @@ class UserGroupViewController: UITableViewController, PanModalPresentable {
         return .contentHeight(300)
     }
     
+    var backgroundInteraction: PanModalBackgroundInteraction { .forward }
+    
     var scrollIndicatorInsets: UIEdgeInsets {
         let bottomOffset = presentingViewController?.bottomLayoutGuide.length ?? 0
         return UIEdgeInsets(top: headerView.frame.size.height, left: 0, bottom: bottomOffset, right: 0)

--- a/Sample/View Controllers/User Groups/UserGroupViewController.swift
+++ b/Sample/View Controllers/User Groups/UserGroupViewController.swift
@@ -94,9 +94,13 @@ class UserGroupViewController: UITableViewController, PanModalPresentable {
     }
 
     var shortFormHeight: PanModalHeight {
-        return isShortFormEnabled ? .contentHeight(300.0) : longFormHeight
+        return .contentHeight(100)
     }
-
+    
+    var mediumFormHeight: PanModalHeight {
+        return .contentHeight(300)
+    }
+    
     var scrollIndicatorInsets: UIEdgeInsets {
         let bottomOffset = presentingViewController?.bottomLayoutGuide.length ?? 0
         return UIEdgeInsets(top: headerView.frame.size.height, left: 0, bottom: bottomOffset, right: 0)

--- a/Tests/PanModalTests.swift
+++ b/Tests/PanModalTests.swift
@@ -55,6 +55,7 @@ class PanModalTests: XCTestCase {
         XCTAssertEqual(vc.allowsExtendedPanScrolling, false)
         XCTAssertEqual(vc.allowsDragToDismiss, true)
         XCTAssertEqual(vc.allowsTapToDismiss, true)
+        XCTAssertEqual(vc.backgroundInteraction, .dismiss)
         XCTAssertEqual(vc.isUserInteractionEnabled, true)
         XCTAssertEqual(vc.isHapticFeedbackEnabled, true)
         XCTAssertEqual(vc.shouldRoundTopCorners, false)


### PR DESCRIPTION
- Add a `mediumForm` so that we are able to have the three bottom sheet states we currently have in Amie (minimized, preview and expanded).
- Add the ability to interact with the background in order to be able to interact with Amie's calendar event when the bottom sheet is open (in any of its states).