### PR TITLE
Add `.forwardToRoot` background interaction

### DIFF
--- a/PanModal/Presentable/PanModalBackgroundInteraction.swift
+++ b/PanModal/Presentable/PanModalBackgroundInteraction.swift
@@ -14,7 +14,10 @@ public enum PanModalBackgroundInteraction: Equatable {
     case dismiss
 
     /** Touches are forwarded to the lower window (In most cases it would be the application main window that will handle it */
-    case forward
+    case forwardToParent
+    
+    /** Touches are forwarded to the first view controller that is not a `PanModalPresentable` */
+    case forwardToRoot
 
      /** Absorbs touches. The modal does nothing (Swallows the touch) */
     case none

--- a/Sample/View Controllers/User Groups/UserGroupViewController.swift
+++ b/Sample/View Controllers/User Groups/UserGroupViewController.swift
@@ -84,6 +84,7 @@ class UserGroupViewController: UITableViewController, PanModalPresentable {
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        presentPanModal(UserGroupViewController())
         tableView.deselectRow(at: indexPath, animated: true)
     }
 
@@ -101,7 +102,9 @@ class UserGroupViewController: UITableViewController, PanModalPresentable {
         return .contentHeight(300)
     }
     
-    var backgroundInteraction: PanModalBackgroundInteraction { .forward }
+    var backgroundInteraction: PanModalBackgroundInteraction { .forwardToRoot }
+    
+    var panModalBackgroundColor: UIColor { .clear }
     
     var scrollIndicatorInsets: UIEdgeInsets {
         let bottomOffset = presentingViewController?.bottomLayoutGuide.length ?? 0
@@ -124,5 +127,4 @@ class UserGroupViewController: UITableViewController, PanModalPresentable {
         isShortFormEnabled = false
         panModalSetNeedsLayoutUpdate()
     }
-
 }


### PR DESCRIPTION
- Change `.forward` to `.forwardToParent` since the touches are being propagated to the `presentingViewController`
- Add `.fowardToRoot` to propagate touches to the first non-`PanModalPresentable` view controller in the presentation stack.