### PR TITLE
Convert background tap point

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -125,12 +125,16 @@ open class PanModalPresentationController: UIPresentationController {
             switch backgroundInteraction {
             case .forwardToParent:
                 view.hitTestHandler = { [weak self] (point, event) in
-                    return self?.presentingViewController.view.hitTest(point, with: event)
+                    guard let viewController = self?.presentingViewController else { return nil }
+                    let converted = viewController.view.convert(point, from: view)
+                    return viewController.view.hitTest(converted, with: event)
                 }
-                
+                            
             case .forwardToRoot:
                 view.hitTestHandler = { [weak self] (point, event) in
-                    self?.rootPresentingViewController?.view.hitTest(point, with: event)
+                    guard let viewController = self?.rootPresentingViewController else { return nil }
+                    let converted = viewController.view.convert(point, from: view)
+                    return viewController.view.hitTest(converted, with: event)
                 }
                 
             case .dismiss:

--- a/PanModalDemo.xcodeproj/project.pbxproj
+++ b/PanModalDemo.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		0F2A2C682239C15D003BDB2F /* UIViewController+PanModalPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C072A9220BA82A00124CE1 /* UIViewController+PanModalPresenter.swift */; };
 		0F2A2C692239C162003BDB2F /* DimmedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC13906E216D9458007A3E64 /* DimmedView.swift */; };
 		0F2A2C6A2239C165003BDB2F /* PanContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94795C9C21F03368008045A0 /* PanContainerView.swift */; };
+		4803899426387D1900404115 /* ButtonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4803899326387D1900404115 /* ButtonViewController.swift */; };
 		48EE033725FA8E160069DE6C /* PanModalBackgroundInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48EE033625FA8E160069DE6C /* PanModalBackgroundInteraction.swift */; };
 		48EE034025FA8E320069DE6C /* PanModalBackgroundInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48EE033625FA8E160069DE6C /* PanModalBackgroundInteraction.swift */; };
 		743CABB02225FC9F00634A5A /* UserGroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743CABAF2225FC9F00634A5A /* UserGroupViewController.swift */; };
@@ -95,6 +96,7 @@
 		0F2A2C512239C119003BDB2F /* PanModal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PanModal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0F2A2C532239C119003BDB2F /* PanModal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PanModal.h; sourceTree = "<group>"; };
 		0F2A2C542239C119003BDB2F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4803899326387D1900404115 /* ButtonViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonViewController.swift; sourceTree = "<group>"; };
 		48EE033625FA8E160069DE6C /* PanModalBackgroundInteraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanModalBackgroundInteraction.swift; sourceTree = "<group>"; };
 		743CABAF2225FC9F00634A5A /* UserGroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserGroupViewController.swift; sourceTree = "<group>"; };
 		743CABB12225FD1100634A5A /* UserGroupHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserGroupHeaderView.swift; sourceTree = "<group>"; };
@@ -388,6 +390,7 @@
 				DC139060216D93ED007A3E64 /* SampleViewController.swift */,
 				DC139079216D9AAA007A3E64 /* View Controllers */,
 				DC13905F216D93AB007A3E64 /* Resources */,
+				4803899326387D1900404115 /* ButtonViewController.swift */,
 			);
 			path = Sample;
 			sourceTree = "<group>";
@@ -572,6 +575,7 @@
 				743CB2AA222660D100665A55 /* StackedProfileViewController.swift in Sources */,
 				943904EB2226354100859537 /* BasicViewController.swift in Sources */,
 				DC139073216D9458007A3E64 /* PanModalPresenter.swift in Sources */,
+				4803899426387D1900404115 /* ButtonViewController.swift in Sources */,
 				943904EF2226383700859537 /* NavigationController.swift in Sources */,
 				DC3B2EBE222A58C9000C8A4A /* AlertView.swift in Sources */,
 				74C072A5220BA76D00124CE1 /* PanModalHeight.swift in Sources */,

--- a/Sample/ButtonViewController.swift
+++ b/Sample/ButtonViewController.swift
@@ -1,0 +1,29 @@
+import UIKit
+
+final class ButtonViewController: UIViewController, PanModalPresentable {
+    
+    var panScrollable: UIScrollView? { nil }
+        
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .blue
+        
+        let button = UIButton()
+        button.setTitle("Button", for: .normal)
+        button.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+        view.addSubview(button)
+        
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
+        button.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+    }
+    
+    @objc
+    func buttonTapped() {
+        
+        print("button tapped")
+        
+        presentPanModal(UserGroupViewController())
+    }
+}

--- a/Sample/SampleViewController.swift
+++ b/Sample/SampleViewController.swift
@@ -73,6 +73,7 @@ private extension SampleViewController {
         case userGroups
         case stacked
         case navController
+        case button
 
 
         var presentable: RowPresentable {
@@ -84,6 +85,7 @@ private extension SampleViewController {
             case .userGroups: return UserGroup()
             case .stacked: return Stacked()
             case .navController: return Navigation()
+            case .button: return Button()
             }
         }
 
@@ -120,6 +122,11 @@ private extension SampleViewController {
         struct Stacked: RowPresentable {
             let string: String = "User Groups (Stacked)"
             let rowVC: PanModalPresentable.LayoutType = UserGroupStackedViewController()
+        }
+        
+        struct Button: RowPresentable {
+            let string: String = "Button"
+            let rowVC: PanModalPresentable.LayoutType = ButtonViewController()
         }
     }
 }


### PR DESCRIPTION
When a tap on the background dimmed view occurrs, we propagate the taps to the presenting view controller.

But the point of the tap in the dimmed view may not be the same as in the presenting view (if it does not occupy the whole screen, as an example). 
Because of this, we need to convert the point to its appropriate coordinates in order to correctly propagate the tap.