### PR TITLE
Transition instead of snap

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -166,7 +166,7 @@ open class PanModalPresentationController: UIPresentationController {
                 view.didTap = { [weak self] _ in
                     self?.presentable?.didTapBackground()
                     guard let self = self else { return }
-                    self.snap(toYPosition: self.shortFormYPosition)
+                    self.transition(to: .shortForm)
                 }
                 
                 view.dropSessionDidEnter = { [weak self] in self?.presentable?.didDropSessionEnterBackground() }
@@ -185,7 +185,7 @@ open class PanModalPresentationController: UIPresentationController {
                 view.didTap = { [weak self] _ in
                     self?.presentable?.didTapBackground()
                     guard let self = self else { return }
-                    self.snap(toYPosition: self.shortFormYPosition)
+                    self.transition(to: .shortForm)
                 }
                 
                 view.dropSessionDidEnter = { [weak self] in self?.presentable?.didDropSessionEnterBackground() }


### PR DESCRIPTION
###  Summary

Calling `transition` instead of `snap` fixes the behaviour of getting `willTransition` and `didTransition` calls.